### PR TITLE
Fix the `require` and tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,18 @@ on:
 
 jobs:
   testing:
-    runs-on: ubuntu-latest
+    strategy:
+      # We want to try all combinations, even if one fails
+      fail-fast: false
+      # Run the release version of quarto (empty string) for all OS
+      matrix:
+        quarto_version: ['']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # Additionally, we want to run the `pre-release` version for Ubuntu
+        include:
+          - os: ubuntu-latest
+            quarto_version: pre-release
+    runs-on: ${{ matrix.os }}
     # At some point, we will probably want to setup a strategy matrix here
     # (perhaps, to test with both quarto's latest release and pre-release)
     env:
@@ -21,6 +32,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: ${{ matrix.quarto_version }}
 
       - name: Run tests
         run: quarto run tests/run_tests.ts

--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -11,15 +11,6 @@
     List.
 ]]
 
--- We want to require the Lua files which are in the same folder.
--- However, as we are invoking this file through Pandoc (and potentially
--- Quarto), we do not have control over the `LUA_PATH` environment variable,
--- nor the current working directory.
--- It seems to me that we need to add this current file's directory
--- to the list of searched directories, i.e., `package.path`.
-local current_dir = debug.getinfo(1).source:match("@?(.*/)")
-package.path = package.path .. ";" .. current_dir .. "/?.lua"
-
 -- Some helper functions
 local Helpers = require("acronyms_helpers")
 
@@ -106,6 +97,7 @@ function generateLoA()
 
     -- Create the Header (only if the title is not empty)
     local header = nil
+    local loa_extra_classes = {}
     if Options["loa_title"] ~= "" then
         local loa_classes = {"loa"}
         header = pandoc.Header(1,

--- a/tests/run_tests.ts
+++ b/tests/run_tests.ts
@@ -9,9 +9,9 @@ import {
 } from "https://deno.land/std/fmt/colors.ts";
 // We need `ensureSymlinkSync` to create a symlink to the `_extensions` folder
 // in the root dir.
-import { ensureSymlinkSync } from "https://deno.land/std/fs/ensure_symlink.ts";
+import { ensureSymlinkSync } from "https://deno.land/std/fs/mod.ts";
 // We need `writeAllSync` to write directly to the console (avoids `\n`).
-import { writeAllSync } from "https://deno.land/std/streams/conversion.ts";
+import { writeAllSync } from "https://deno.land/std/streams/mod.ts";
 // We need path manipulations to get the `tests` folder path based on the
 // path to the current running script.
 import {

--- a/tests/run_tests.ts
+++ b/tests/run_tests.ts
@@ -35,6 +35,10 @@ interface TestResult {
     executionTimeMs: number;
 }
 
+// We need this to handle CRLF / LF line separators (thank you Windows...).
+const eolRegex = /\r?\n/;
+const eol = Deno.build.os === "windows" ? "\r\n" : "\n";
+
 
 /*
  * This function returns the path to the `tests` folder.
@@ -69,14 +73,14 @@ function filterStdout (stdout: string) {
     // Unfortunately, Quarto renders the YAML metadata inside the md document
     // (when using the `md` format), contrary to "pure" Pandoc.
     // We need to remove these lines to compare the output to the expected one.
-    let stdoutLines = stdout.split('\n');
+    let stdoutLines = stdout.split(eolRegex);
     const metadataStartIndex = stdoutLines.indexOf('---');
     // We want to find the 2nd `'---'` line, i.e., the one after the first!
     const metadataEndIndex = stdoutLines.indexOf('---', metadataStartIndex + 1);
     // We want to take only lines after the last `---` + 2
     // (+2 because we do not want the '---' itself, nor the next blank line).
     stdoutLines = stdoutLines.slice(metadataEndIndex + 2);
-    stdout = stdoutLines.join('\n');
+    stdout = stdoutLines.join(eol);
     return stdout;
 }
 
@@ -91,7 +95,7 @@ function filterStderr (stderr: string) {
     // Using `--quiet` removes *all* output on stderr, so we cannot use it.
     // We need to filter out the first lines, which consist of 2 "blocks",
     // indented by 2 spaces (`  `). They end by a line with only these spaces.
-    let stderrLines = stderr.split('\n');
+    let stderrLines = stderr.split(eolRegex);
     const endOfFirstBlock = stderrLines.indexOf('  ');
     const endOfSecondBlock = stderrLines.indexOf('  ', endOfFirstBlock + 1);
     // Now, take only the lines following these blocks.
@@ -100,7 +104,7 @@ function filterStderr (stderr: string) {
     // empty line).
     const outputCreatedLine = stderrLines.indexOf('Output created: input.md');
     stderrLines.splice(outputCreatedLine, 2);
-    stderr = stderrLines.join('\n');
+    stderr = stderrLines.join(eol);
     return stderr;
 }
 


### PR DESCRIPTION
On Windows, modifying the package load path before `require`-ing our .lua files did not work.
In addition, it was difficult to identify bugs for Windows, because of a lack of automated testing.

This PR:
- adds new automated tests (the same as previously, but running on Linux/macOS/Windows instead of just Windows);
- fixes the tests for Windows (they did not work because Quarto could not output to stdout on Windows, and because of CRLF handling);
- fixes the `require` problem.

This solves Issue #8 