### PR TITLE
Improved error messages

### DIFF
--- a/_extensions/acronyms/acronyms.lua
+++ b/_extensions/acronyms/acronyms.lua
@@ -99,13 +99,15 @@ end
 
 -- Add a new acronym to the table. Also handles duplicates.
 function Acronyms:add(acronym, on_duplicate)
+    quarto.log.debug("[acronyms] Trying to add a new acronym...", acronym)
     assert(acronym.key ~= nil,
-        "The acronym key should not be nil!")
+        "[acronyms] The acronym key should not be nil in Acronyms:add!")
     assert(on_duplicate ~= nil,
-        "on_duplicate should not be nil!")
+        "[acronyms] The parameter on_duplicate should not be nil in Acronyms:add!")
 
     -- Handling duplicate keys
     if self:contains(acronym.key) then
+        quarto.log.debug("[acronyms] Found an acronym with a duplicate key: ", acronym.key)
         if on_duplicate == "replace" then
             -- Do nothing, let us replace the previous acronym.
         elseif on_duplicate == "keep" then
@@ -113,13 +115,15 @@ function Acronyms:add(acronym, on_duplicate)
             return
         elseif on_duplicate == "warn" then
             -- Warn, and do not replace.
-            warn("Duplicate key: ", acronym.key)
+            quarto.log.warning("[acronyms] Found an acronym with a duplicate key: ", acronym.key)
             return
         elseif on_duplicate == "error" then
             -- Stop execution.
-            error("Duplicate key: " .. acronym.key)
+            quarto.log.error("[acronyms] Found an acronym with a duplicate key: ", acronym.key)
+            assert(false)
         else
-            error("Unrecognized option on_duplicate = " .. on_duplicate)
+            quarto.log.error("[acronyms] Unrecognized option `on_duplicate`=", tostring(on_duplicate), " in Acronyms:add.")
+            assert(false)
         end
     end
 
@@ -131,13 +135,15 @@ end
 
 -- Populate the Acronyms database from a YAML metadata
 function Acronyms:parseFromMetadata(metadata, on_duplicate)
+    quarto.log.debug("[acronyms] Parsing acronyms from metadata...", metadata.acronyms)
     -- We expect the acronyms to be in the `metadata.acronyms.keys` field.
     if not (metadata and metadata.acronyms and metadata.acronyms.keys) then
         return
     end
     -- This field should be a Pandoc "MetaList" (so we can iter over it).
     if not Helpers.isMetaList(metadata.acronyms.keys) then
-        error("The acronyms.keys should be a list!")
+        quarto.log.error("[acronyms] The `acronyms.keys` metadata should be a list!")
+        assert(false)
     end
 
     -- Iterate over the defined acronyms. We use `ipairs` since we want to
@@ -161,13 +167,14 @@ end
 -- Populate the Acronyms database from a YAML file
 -- Inspired from https://github.com/dsanson/pandoc-abbreviations.lua/
 function Acronyms:parseFromYamlFile(filepath, on_duplicate)
+    quarto.log.debug("[acronyms] Trying to parse acronyms from file: ", filepath)
     assert(filepath ~= nil,
-        "filepath must not be nil!")
+        "[acronyms] filepath must not be nil when parsing from external file!")
 
     -- First, read the file's content.
     local file = io.open(filepath, "r")
     if file == nil then
-        warn("File ", filepath, " could not be read! (does not exist?)")
+        quarto.log.warning("[acronyms] File ", filepath, " could not be read! (does not exist?)")
         return
     end
     local content = file:read("*a")

--- a/_extensions/acronyms/acronyms_helpers.lua
+++ b/_extensions/acronyms/acronyms_helpers.lua
@@ -62,4 +62,17 @@ function Helpers.key_to_link(key)
 end
 
 
+-- Helper to print a Pandoc Metadata.
+-- From a metadata (e.g., a YAML map), it returns a table-like string:
+-- `{ key1: value1 ; key2: value2 ; ... }`.
+function Helpers.metadata_to_str(metadata)
+    -- We need to reformat a bit the table
+    local t = {}
+    for k, v in pairs(metadata) do
+        table.insert(t, k .. ": " .. pandoc.utils.stringify(v))
+    end
+    return "{ " .. table.concat(t, " ; ") .. " }"
+end
+
+
 return Helpers

--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -49,6 +49,7 @@ local Options = {
 Parse the options from the Metadata (i.e., the YAML fields).
 --]]
 function Options:parseOptionsFromMetadata(m)
+    quarto.log.debug("[acronyms] Parsing options from metadata...", m.acronyms)
     -- The options that we are interested in are all grouped under `acronyms`.
     -- If it does not exist, use an empty table.
     options = m.acronyms or {}

--- a/_extensions/acronyms/acronyms_styles.lua
+++ b/_extensions/acronyms/acronyms_styles.lua
@@ -117,13 +117,13 @@ end
 return function(acronym, style_name, insert_links)
     -- Check that the requested strategy exists
     assert(style_name ~= nil,
-        "style_name must not be nil!")
+        "[acronyms] The parameter style_name must not be nil!")
     assert(styles[style_name] ~= nil,
-        "Style " .. style_name .. " does not exist!")
+        "[acronyms] Style " .. style_name .. " does not exist!")
 
     -- Check that the acronym exists
     assert(acronym ~= nil,
-        "acronym must not be nil!")
+        "[acronyms] The acronym must not be nil!")
 
     -- Call the style on this acronym
     return styles[style_name](acronym, insert_links)

--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -34,19 +34,6 @@ to register the order in which acronyms appear.
 local current_order = 0
 
 
--- A helper function to print warnings
-function warn(...)
-    -- Handle variadic args: use `tostring` to avoid errors
-    -- (in particular for table or nil values)
-    local t = table.pack(...)
-    for i=1, t.n do
-        t[i] = tostring(t[i])
-    end
-    local msg = table.concat(t, "")
-    io.stderr:write("[WARNING][acronymsdown] ", msg, "\n")
-end
-
-
 function Meta(m)
     Options:parseOptionsFromMetadata(m)
 
@@ -101,12 +88,12 @@ function generateLoA()
     if Options["loa_title"] ~= "" then
         local loa_classes = {"loa"}
         header = pandoc.Header(1,
-            { table.unpack(Options["loa_title"]) },
-            pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
-        )
-    end
+        { table.unpack(Options["loa_title"]) },
+        pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
+    )
+end
 
-    return header, pandoc.DefinitionList(definition_list)
+return header, pandoc.DefinitionList(definition_list)
 end
 
 
@@ -125,8 +112,12 @@ function appendLoA(doc)
         -- Insert at the last block in the document
         pos = #doc.blocks + 1
     else
-        error("Unrecognized option insert_loa="
-                .. tostring(Options["insert_loa"]))
+        quarto.log.error(
+            "[acronyms] Unrecognized option `insert_loa`=`",
+            tostring(Options["insert_loa"]),
+            "` in `appendLoA`."
+        )
+        assert(false)
     end
 
     local header, definition_list = generateLoA()
@@ -175,17 +166,25 @@ function replaceNonExistingAcronym(acr_key)
     -- TODO: adding the source line to warnings would be useful.
     --  But maybe not doable in Pandoc?
     if Options["non_existing"] == "key" then
-        warn("Acronym key ", acr_key, " not recognized")
+        quarto.log.warning("[acronyms] Acronym key", acr_key, "not recognized")
         return pandoc.Str(acr_key)
     elseif Options["non_existing"] == "??" then
-        warn("Acronym key ", acr_key, " not recognized")
+        quarto.log.warning("[acronyms] Acronym key", acr_key, "not recognized")
         return pandoc.Str("??")
     elseif Options["non_existing"] == "error" then
-        error("Acronym key " .. tostring(acr_key)
-                .. " not recognized, stopping!")
+        quarto.log.error(
+            "[acronyms] Acronym key",
+            tostring(acr_key),
+            "not recognized, stopping!"
+        )
+        assert(false)
     else
-        error("Unrecognized option non_existing="
-                .. tostring(Options["non_existing"]))
+        quarto.log.error(
+            "[acronyms] Unrecognized option `non_existing`=`",
+            tostring(Options["non_existing"]),
+            "` when replacing acronyms."
+        )
+        assert(false)
     end
 end
 

--- a/_extensions/acronyms/sort_acronyms.lua
+++ b/_extensions/acronyms/sort_acronyms.lua
@@ -45,17 +45,26 @@ end
 -- The "public" API, i.e., the function returned by `require`.
 function sort_acronyms(acronyms, criterion, include_unused)
     assert(acronyms ~= nil,
-        "The acronyms table must not be nil!")
+        "[acronyms] The acronyms table must not be nil in sort_acronyms!")
     assert(criterion ~= nil,
-        "The criterion must be not nil!")
+        "[acronyms] The criterion must be not nil in sort_acronyms!")
     local comparator = sorting_strategies[criterion]
-    assert(comparator ~= nil,
-        "Sorting criterion unrecognized: " .. criterion)
+    if (comparator == nil) then
+        local msg = "[acronyms] Error when sorting acronyms:\n"
+        msg = msg .. "! Sorting criterion unrecognized: " .. tostring(criterion) .. "\n"
+        msg = msg .. "i Please check the `acronyms.sorting` metadata option.\n"
+        quarto.log.error(msg)
+        assert(false)
+    end
 
     -- Special rule: cannot use `usage` criterion if `include_unused` is true.
     -- Otherwise, comparison of potentially nil values will crash.
     if criterion == "usage" and include_unused then
-        error("When the 'usage' sorting is used, 'include_unused' must be set to false!")
+        local msg = "[acronyms] Error when sorting acronyms:\n"
+        msg = msg .. "! Cannot sort by `usage` when `include_unused` is true\n"
+        msg = msg .. "i Please set another sorting or set `include_unused` to `false`."
+        quarto.log.error(msg)
+        assert(false)
     end
 
     -- The acronyms table is indexed by keys, not by ints. Thus,

--- a/tests/11-missing-key/expected.stderr
+++ b/tests/11-missing-key/expected.stderr
@@ -1,2 +1,2 @@
-[WARNING][acronymsdown] Acronym key RL not recognized
-[WARNING][acronymsdown] Acronym key RL not recognized
+(W) [acronyms] Acronym key RL not recognized
+(W) [acronyms] Acronym key RL not recognized

--- a/tests/12-missing-unknown/expected.stderr
+++ b/tests/12-missing-unknown/expected.stderr
@@ -1,2 +1,2 @@
-[WARNING][acronymsdown] Acronym key RL not recognized
-[WARNING][acronymsdown] Acronym key RL not recognized
+(W) [acronyms] Acronym key RL not recognized
+(W) [acronyms] Acronym key RL not recognized


### PR DESCRIPTION
Improved most error and warning messages by using the `quarto.log` library.

For errors specifically, we must also resort to using `assert` because simply logging the message does not stop execution (which would lead the filter into an unstable state).
The standard `error` function in Lua has been redefined by Quarto and no longer stops execution as well.
At some point, we should be able to use `fatal` or `fail`, but they seem not to be defined in all versions...

The error when an acronym is not correctly configured (i.e., missing shortname or longname) has been greatly improved, to be more verbose and readable for end users. Some internal errors have been kept concise, because they should not appear to end users.