### PR TITLE
Allow to specify additional classes for the List of Acronyms header

### DIFF
--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -42,6 +42,9 @@ local Options = {
     -- replacing (rendering) an acronym.
     insert_links = true,
 
+    -- Additional classes to add to the List of Acronyms header.
+    loa_header_classes = {},
+
 }
 
 
@@ -106,6 +109,12 @@ function Options:parseOptionsFromMetadata(m)
     if options["insert_links"] ~= nil then
         -- This value should be a boolean here, we do not need to stringify it.
         self.insert_links = options["insert_links"]
+    end
+
+    if options["loa_header_classes"] ~= nil then
+        for _, v in ipairs(options["loa_header_classes"]) do
+            table.insert(self.loa_header_classes, pandoc.utils.stringify(v))
+        end
     end
 end
 

--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -84,16 +84,18 @@ function generateLoA()
 
     -- Create the Header (only if the title is not empty)
     local header = nil
-    local loa_extra_classes = {}
     if Options["loa_title"] ~= "" then
-        local loa_classes = {"loa"}
+        local extra_classes = Options["loa_header_classes"]
+        -- Create a table specifically for this LoA, and copy all "extra classes"
+        -- (from the Options) to this table. The table will also contain `"loa"`.
+        local loa_classes = table.move(extra_classes, 1, #extra_classes, 2, {"loa"})
         header = pandoc.Header(1,
-        { table.unpack(Options["loa_title"]) },
-        pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
-    )
-end
+            { table.unpack(Options["loa_title"]) },
+            pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
+        )
+    end
 
-return header, pandoc.DefinitionList(definition_list)
+    return header, pandoc.DefinitionList(definition_list)
 end
 
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -27,6 +27,7 @@ website:
         menu:
           - advanced/external_file.qmd
           - advanced/multi_document.qmd
+          - advanced/customized_loa_header.qmd
     right:
       - text: Source Code
         href: https://github.com/rchaput/acronyms

--- a/docs/advanced/customized_loa_header.qmd
+++ b/docs/advanced/customized_loa_header.qmd
@@ -1,0 +1,83 @@
+---
+title: "Customizing the List of Acronyms title"
+description: >
+  Read how to customize the List of Acronyms title (header), including putting
+  it in an unnumbered section.
+---
+
+
+## Using an unnumbered section
+
+By default, the List Of Acronyms (loa) is generated with its own header;
+depending on your document configuration, this header may be numbered.
+
+To obtain an unnumbered section, you may add the extra class `unnumbered`
+(as per the standard Pandoc and Quarto way to create an unnumbered section)
+by using the `loa_header_classes` metadata option.
+
+For example:
+
+```md
+---
+format:
+  pdf:
+    number-sections: true
+acronyms:
+  loa_header_classes:
+    - unnumbered
+  keys:
+    - shortname: qmd
+      longname: Quarto document
+---
+
+# Introduction
+
+Using an acronym: \acr{qmd}
+```
+
+This will generate a PDF with sections `List of Acronyms` (unnumbered), and
+`1. Introduction` (numbered). Note that the List of Acronyms is, by default,
+generated at the beginning of the document, but you may customize it to put
+at the end, or even at your desired location, by using the [options].
+
+
+## Manually customizing the title
+
+You may also want to fully customize the header of the List of Acronyms; this
+can be done by disabling the automatic generation, and then writing your
+own header, for which you can leverage all Pandoc and Quarto features.
+
+To do so, simply set the [insert_loa] option to `false` to disable the
+automatic generation of the List of Acronyms, and set [loa_title] to `''` (the
+empty string) to disable the generation of the header.
+You may then write exactly what you want as a header, and use `\printacronyms`
+to generate the List of Acronyms after your header.
+
+For example, to use a level-2 header (*subsection*):
+
+```md
+---
+acronyms:
+  insert_loa: false
+  loa_title: ''
+  keys:
+    - shortname: qmd
+      longname: Quarto document
+---
+
+# Introduction
+
+Using an acronym: \acr{qmd}
+
+## List of Acronyms in a subsection
+
+\printacronyms
+
+# Another section
+
+At the end of the document
+```
+
+[options]: ../articles/options.qmd
+[loa_title]: ../articles/options.qmd#loa_title
+[insert_loa]: ../articles/options.qmd#insert_loa

--- a/docs/advanced/index.qmd
+++ b/docs/advanced/index.qmd
@@ -1,0 +1,12 @@
+---
+title: "Advanced usage tutorials"
+listing:
+  type: default
+  sort: "date"
+  # Customize fields to improve appearance
+  fields: [title, description]
+  # Ignore self page
+  exclude:
+    title: "Advanced usage tutorials"
+  sort-ui: false
+---

--- a/docs/articles/options.qmd
+++ b/docs/articles/options.qmd
@@ -387,7 +387,8 @@ inside the YAML metadata~; however, you can use `fromfile`
 to specify external YAML files from which acronyms should be
 loaded.
 
-Its usage is described in details in [Advanced usage](advanced_usage.qmd).
+Its usage is described in details in
+[Advanced usage](../advanced/external_file.qmd).
 
 
 ## `style`

--- a/docs/articles/options.qmd
+++ b/docs/articles/options.qmd
@@ -19,6 +19,7 @@ along with their default values.
 ---
 acronyms:
   loa_title: "List of Acronyms"
+  loa_header_classes: []
   include_unused: true
   insert_loa: "beginning"
   insert_links: true
@@ -62,6 +63,29 @@ To disable the title:
 ---
 acronyms:
   loa_title: ""
+---
+```
+
+
+## `loa_header_classes`
+
+This options allows to add more classes to the List Of Acronyms (loa) header.
+By default, the header uses the `loa` class, which should not do anything by
+itself. It may be used to customize the LoA with CSS rules, but has no default
+behaviour.
+
+Any additional class can be put to the LoA by putting them in this option,
+in the form of a list. By default, this list is empty, which means that the
+LoA only has the `loa` class.
+
+*Examples*:
+
+To put the LoA in an unnumbered section:
+```yaml
+---
+acronyms:
+  loa_header_classes:
+    - unnumbered
 ---
 ```
 

--- a/docs/getting_started.qmd
+++ b/docs/getting_started.qmd
@@ -113,8 +113,8 @@ The current vignette gives you the tools for a simple document, using the
 However, most of the mechanisms are highly configurable and offer various
 options.
 
-An advanced usage is covered in [Advanced Usage][advanced_usage], while the
-available options are described in [Options][options].
+Available options are described in [Options][options], and several tutorials
+for advanced usages are listed in [Advanced usage][advanced_usage].
 
 [Styles][styles] lists the different styles that can be used, along
 with a small example to visualize each of them.
@@ -124,5 +124,5 @@ with a small example to visualize each of them.
 [Lua Filter]: https://pandoc.org/lua-filters.html
 [styles]: articles/styles.qmd
 [example]: https://github.com/rchaput/acronyms/blob/master/example.qmd
-[advanced_usage]: articles/advanced_usage.qmd
+[advanced_usage]: advanced/index.qmd
 [options]: articles/options.qmd

--- a/tests/21-loa-unnumbered-section/Readme.md
+++ b/tests/21-loa-unnumbered-section/Readme.md
@@ -1,0 +1,6 @@
+This test shows how to put the List of Acronyms in an unnumbered section.
+
+The LoA header (title above the LoA itself) has the `loa` class by default,
+which does not do anything, but can be used to style the LoA in CSS. In
+addition, "extra" classes can be put on the header, to further configure it,
+such as `unnumbered`, which will effectively create an unnumbered section.

--- a/tests/21-loa-unnumbered-section/expected.md
+++ b/tests/21-loa-unnumbered-section/expected.md
@@ -1,0 +1,10 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa .unnumbered}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And now, in this paragraph, [RL](#acronyms_RL) is in short form.

--- a/tests/21-loa-unnumbered-section/input.qmd
+++ b/tests/21-loa-unnumbered-section/input.qmd
@@ -1,0 +1,14 @@
+---
+acronyms:
+  loa_header_classes:
+    - unnumbered
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+---
+
+# Introduction {#intro}
+
+This paragraph mentions \acr{RL} for the first time.
+
+And now, in this paragraph, \acr{RL} is in short form.


### PR DESCRIPTION
The List of Acronyms (LoA) header uses the `loa` class by default, which does not do anything.
These changes create a new option `loa_header_classes` that can be used to customize the header classes, and in particular to make it an unnumbered section.

The docs are also improved to include the new option, as well as an "advanced usage" tutorial on how to customize the header.
The behaviour of `loa_header_classes` is tested by a new automatic test.

This PR solves Issue #6.