### PR TITLE
Shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ provided the same features, but for [RMarkdown][rmarkdown] documents.
 
 ![Example of acronyms document](preview.png)
 
+:fire: Now with the Quarto shortcode syntax!
+
 
 ## Features
 
@@ -100,11 +102,16 @@ acronyms:
 ---
 ```
 
-2. Use your acronyms in your qmd document with the `\acr{<KEY>}` special command!
+2. Use your acronyms in your qmd document. You may use the older syntax with
+   the `\acr{KEY}` special command:
 
 `\acr{qmd} can be used to write technical content. \acr{qmd} use \acr{YAML}.`
 
-which renders as (using default options):
+or the newer shortcode syntax `{{< acr KEY >}}`:
+
+`{{< acr qmd >}} can be used to write technical content. {{< acr qmd >}} use {<< acr YAML >}}.`
+
+Both syntaxes render as (using default options):
 
 > Quarto documents can be used to write technical content. qmd use YAML Ain't Markup Language.
 

--- a/_extensions/acronyms/_extension.yml
+++ b/_extensions/acronyms/_extension.yml
@@ -1,7 +1,9 @@
 title: acronyms
 author: rchaput
 version: 1.0.0
-quarto-required: ">=1.2.0"
+quarto-required: ">=1.4.0"
 contributes:
   filters:
     - parse-acronyms.lua
+  shortcodes:
+    - shortcodes_acronyms.lua

--- a/_extensions/acronyms/_extension.yml
+++ b/_extensions/acronyms/_extension.yml
@@ -1,6 +1,6 @@
 title: acronyms
 author: rchaput
-version: 1.0.0
+version: 2.0.0
 quarto-required: ">=1.4.0"
 contributes:
   filters:

--- a/_extensions/acronyms/acronyms.lua
+++ b/_extensions/acronyms/acronyms.lua
@@ -126,6 +126,8 @@ end
 -- Add a new acronym to the table. Also handles duplicates.
 function Acronyms:add(acronym, on_duplicate)
     quarto.log.debug("[acronyms] Trying to add a new acronym...", acronym)
+    assert(acronym ~= nil,
+        "[acronyms] The acronym should not be nil in Acronyms:add!")
     assert(acronym.key ~= nil,
         "[acronyms] The acronym key should not be nil in Acronyms:add!")
     assert(on_duplicate ~= nil,

--- a/_extensions/acronyms/acronyms.lua
+++ b/_extensions/acronyms/acronyms.lua
@@ -106,6 +106,12 @@ Acronyms = {
     -- count of the order in which acronyms are defined.
     current_definition_order = 0,
 
+    -- The current "usage order" value.
+    -- We increment this value each time an acronym is used for the first time,
+    -- to keep count of their order of appearance. This can be necessary for
+    -- generating the List of Acronyms, depending on the desired order.
+    current_usage_order = 0,
+
     -- Access to the `Acronym` class, if necessary.
     Acronym = Acronym,
 }
@@ -158,6 +164,14 @@ function Acronyms:add(acronym, on_duplicate)
     self.current_definition_order = self.current_definition_order + 1
     acronym.definition_order = self.current_definition_order
     self.acronyms[acronym.key] = acronym
+end
+
+
+function Acronyms:setAcronymUsageOrder(acronym)
+    assert(acronym ~=nil,
+        "[acronyms] The acronym should not be nil in Acronyms:setAcronymUsageOrder!")
+    self.current_usage_order = self.current_usage_order + 1
+    acronym.usage_order = self.current_usage_order
 end
 
 

--- a/_extensions/acronyms/acronyms_pandoc.lua
+++ b/_extensions/acronyms/acronyms_pandoc.lua
@@ -1,0 +1,177 @@
+--[[
+    Functions to generate Pandoc elements.
+
+    These functions are independent of the "entrypoint" script: they work
+    with both:
+    - filters (i.e., scripts that parse the Pandoc content and react to various
+      elements);
+    - shortcodes (i.e., scripts that are triggered by the new Quarto syntax,
+      `{{< shortcode-name args >}}`).
+
+    This allows **acronyms** to work with its legacy filter mode, by reacting
+    to `\acr{key}` and `\printacronyms` elements, and with the new shortcode
+    syntax. However, due to the way it was coded, the legacy filter mode will
+    not support arguments and keyworded arguments. The shortcode mode is
+    particularly suited for these new features, as it is handled by Quarto
+    itself directly. It will be easier for users to customize a specific
+    acronym or list of acronym, rather than specifying options in the Metadata.
+]]
+
+-- The Acronyms database
+local Acronyms = require("acronyms")
+
+-- Some helper functions
+local Helpers = require("acronyms_helpers")
+
+-- Sorting function
+local sortAcronyms = require("sort_acronyms")
+
+-- Replacement function (handling styles)
+local replaceExistingAcronymWithStyle = require("acronyms_styles")
+
+-- The options for the List Of Acronyms, as defined in the document's metadata.
+local Options = require("acronyms_options")
+
+-- The functions that we define here, and which will generate Pandoc elements
+local AcronymsPandoc = {}
+
+
+--[[
+    Replace an acronym whose key is not found in the `acronyms` table with the
+    corresponding Pandoc elements.
+
+    Params:
+    - acr_key: the acronym's key (identifier).
+    - non_existing: controls which behaviour to use:
+        - `key` => warn, and simply return the key as a Pandoc text
+        - `??` => warn, and return `"??"` as a pandoc Text (similar to bibtex's
+            behaviour)
+        - `error` => raise an error, and stop execution
+--]]
+function AcronymsPandoc.replaceNonExistingAcronym(acr_key, non_existing)
+    -- TODO: adding the source line to warnings would be useful.
+    --  But maybe not doable in Pandoc?
+    
+    -- Use default option if not set
+    non_existing = non_existing or Options["non_existing"]
+
+    if non_existing == "key" then
+        quarto.log.warning("[acronyms] Acronym key", acr_key, "not recognized")
+        return pandoc.Str(acr_key)
+    elseif non_existing == "??" then
+        quarto.log.warning("[acronyms] Acronym key", acr_key, "not recognized")
+        return pandoc.Str("??")
+    elseif non_existing == "error" then
+        quarto.log.error(
+            "[acronyms] Acronym key",
+            tostring(acr_key),
+            "not recognized, stopping!"
+        )
+        assert(false)
+    else
+        quarto.log.error(
+            "[acronyms] Unrecognized option `non_existing`=`",
+            tostring(non_existing),
+            "` when replacing acronyms."
+        )
+        assert(false)
+    end
+end
+
+
+--[[
+    Replace an acronym identified by its key, which exists in the `acronyms`
+    table, and generate the corresponding Pandoc elements.
+
+    Params:
+    - key: identifies the acronym to replace.
+    - style: the style to use when replacing (see the `acronyms_styles.lua` file).
+    - first_use: whether we want to print this acronym as its first use, or
+        a "next use". Set to `nil` to use the acronym's own counter, or override
+        it directly by setting to `true` or `false`.
+    - insert_links: whether to insert a link to this acronym's definition in
+        the List of Acronyms.
+--]]
+function AcronymsPandoc.replaceExistingAcronym(acr_key, style, first_use, insert_links)
+    quarto.log.debug("[acronyms] Replacing acronym", acr_key)
+    local acronym = Acronyms:get(acr_key)
+    acronym:incrementOccurrences()
+    if acronym:isFirstUse() then
+        -- This acronym never appeared! We first set its usage order.
+        Acronyms:setAcronymUsageOrder(acronym)
+    end
+
+    -- Use default values from Options if not specified
+    style = style or Options["style"]
+    insert_links = insert_links or Options["insert_links"]
+
+    -- Replace the acronym with the desired style
+    return replaceExistingAcronymWithStyle(
+        acronym,
+        style,
+        insert_links,
+        first_use
+    )
+end
+
+
+--[[
+    Generate the List Of Acronyms.
+
+    Returns 2 values: the Header, and the DefinitionList.
+
+    Params:
+    - sorting: the sorting method to use.
+    - include_unused: whether to include unused acronyms.
+    - title: the header title ; use `''` (the empty string) to avoid generating
+        a header (the user wants to create the header manually).
+    - header_classes: the table of extra classes to put to the header.
+--]]
+function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_classes)
+    -- Original idea from https://gist.github.com/RLesur/e81358c11031d06e40b8fef9fdfb2682
+
+    -- Use default options if not specified
+    sorting = sorting or Options["sorting"]
+    include_unused = include_unused or Options["include_unused"]
+    title = title or Options["loa_title"]
+    header_classes = header_classes or Options["loa_header_classes"]
+
+    -- We first get the list of sorted acronyms, according to the defined criteria.
+    local sorted = sortAcronyms(
+        Acronyms.acronyms,
+        sorting,
+        include_unused
+    )
+
+    -- Create the table that represents the DefinitionList
+    local definition_list = {}
+    for _, acronym in ipairs(sorted) do
+        -- The definition's name. A Span with an ID so we can create a link.
+        local name = pandoc.Span(
+            acronym.shortname,
+            pandoc.Attr(Helpers.key_to_id(acronym.key), {}, {})
+        )
+        -- The definition's value.
+        local definition = pandoc.Plain(acronym.longname)
+        table.insert(definition_list, { name, definition })
+    end
+
+    -- Create the Header (only if the title is not empty)
+    local header = nil
+    if title ~= "" then
+        local extra_classes = header_classes
+        -- Create a table specifically for this LoA, and copy all "extra classes"
+        -- (from the Options) to this table. The table will also contain `"loa"`.
+        local loa_classes = table.move(extra_classes, 1, #extra_classes, 2, {"loa"})
+        header = pandoc.Header(
+            1,
+            { table.unpack(title) },
+            pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
+        )
+    end
+
+    return header, pandoc.DefinitionList(definition_list)
+end
+
+
+return AcronymsPandoc

--- a/_extensions/acronyms/acronyms_styles.lua
+++ b/_extensions/acronyms/acronyms_styles.lua
@@ -52,9 +52,9 @@ end
 
 -- First use: long name (short name)
 -- Next use: short name
-styles["long-short"] = function(acronym, insert_links)
+styles["long-short"] = function(acronym, insert_links, is_first_use)
     local text
-    if acronym:isFirstUse() then
+    if is_first_use then
         text = acronym.longname .. " (" .. acronym.shortname .. ")"
     else
         text = acronym.shortname
@@ -66,9 +66,9 @@ end
 
 -- First use: short name (long name)
 -- Next use: short name
-styles["short-long"] = function(acronym, insert_links)
+styles["short-long"] = function(acronym, insert_links, is_first_use)
     local text
-    if acronym:isFirstUse() then
+    if is_first_use then
         text = acronym.shortname .. " (" .. acronym.longname .. ")"
     else
         text = acronym.shortname
@@ -89,8 +89,8 @@ end
 -- First use: short name [^1]
 -- [^1]: short name: long name
 -- Next use: short name
-styles["short-footnote"] = function(acronym, insert_links)
-    if acronym:isFirstUse() then
+styles["short-footnote"] = function(acronym, insert_links, is_first_use)
+    if is_first_use then
         -- The inline text (before the footnote)
         local text = pandoc.Str(acronym.shortname)
         -- We create a footnote, which must contain a Block with a Link and
@@ -114,7 +114,7 @@ end
 
 -- The "public" API of this module, the function which is returned by
 -- require.
-return function(acronym, style_name, insert_links)
+return function(acronym, style_name, insert_links, is_first_use)
     -- Check that the requested strategy exists
     assert(style_name ~= nil,
         "[acronyms] The parameter style_name must not be nil!")
@@ -125,6 +125,10 @@ return function(acronym, style_name, insert_links)
     assert(acronym ~= nil,
         "[acronyms] The acronym must not be nil!")
 
+    -- Determine if it is the first use (if left unspecified)
+    if is_first_use == nil then
+        is_first_use = acronym:isFirstUse()
+    end
     -- Call the style on this acronym
-    return styles[style_name](acronym, insert_links)
+    return styles[style_name](acronym, insert_links, is_first_use)
 end

--- a/_extensions/acronyms/acronyms_styles.lua
+++ b/_extensions/acronyms/acronyms_styles.lua
@@ -119,7 +119,7 @@ return function(acronym, style_name, insert_links, is_first_use)
     assert(style_name ~= nil,
         "[acronyms] The parameter style_name must not be nil!")
     assert(styles[style_name] ~= nil,
-        "[acronyms] Style " .. style_name .. " does not exist!")
+        "[acronyms] Style " .. tostring(style_name) .. " does not exist!")
 
     -- Check that the acronym exists
     assert(acronym ~= nil,

--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -26,13 +26,6 @@ local replaceExistingAcronymWithStyle = require("acronyms_styles")
 -- The options for the List Of Acronyms, as defined in the document's metadata.
 local Options = require("acronyms_options")
 
---[[
-The current "usage order" value.
-We increment this value each time we find a new acronym, and we use it
-to register the order in which acronyms appear.
---]]
-local current_order = 0
-
 
 function Meta(m)
     Options:parseOptionsFromMetadata(m)
@@ -198,8 +191,7 @@ function replaceExistingAcronym(acr_key)
     acronym:incrementOccurrences()
     if acronym:isFirstUse() then
         -- This acronym never appeared! We first set its usage order.
-        current_order = current_order + 1
-        acronym.usage_order = current_order
+        Acronyms:setAcronymUsageOrder(acronym)
     end
 
     -- Replace the acronym with the desired style

--- a/_extensions/acronyms/shortcodes_acronyms.lua
+++ b/_extensions/acronyms/shortcodes_acronyms.lua
@@ -1,0 +1,89 @@
+--[[
+    Quarto Shortcodes to replace acronyms in a Quarto document.
+
+    Acronyms must be in the form `{{< acr key >}}` where key is the acronym key.
+    The shortcode format (contrary to filters) allows specifying keyworded
+    arguments to better control the output (e.g., specific style, forcing first
+    or next occurrence, etc.).
+
+    The List of Acronyms can also be generated with the `{{< printacronyms >}}`
+    shortcode.
+
+    The filter (`parse-acronyms.lua`) remains useful even if only shortcodes
+    are used (i.e., no `\acr{key}`): it is responsible for parsing the metadata
+    once, and automatically appending the LoA (if the user sets the Options
+    accordingly).
+]]
+
+-- Some helper functions
+local Helpers = require("acronyms_helpers")
+
+-- The Acronyms database
+local Acronyms = require("acronyms")
+
+-- Replacement functions
+local AcronymsPandoc = require("acronyms_pandoc")
+
+-- The options for the List Of Acronyms, as defined in the document's metadata.
+local Options = require("acronyms_options")
+
+
+--[[
+    Define the "main" shortcode behaviour: replacing an acronym.
+
+    This function is associated to shortcodes `acronym` and `acr` so that it is
+    invoked through `{{< acr KEY >}}` or `{{< acronym KEY >}}`.
+--]]
+function replaceAcronym (args, kwargs, meta)
+    -- We want exactly 1 (unnamed) argument for the shortcode.
+    if #args == 0 or #args > 1 then
+        quarto.log.error(
+            "[acronyms] Incorrect number of arguments in shortcode `acronym`!\n",
+            "! Expected exactly 1 argument (the acronym key).\n",
+            "x Found ", tostring(#args), ".\n",
+            "i The arguments were: `", pandoc.utils.stringify(args), "`.\n"
+        )
+        assert(false)
+    end
+
+    local acronym_key = pandoc.utils.stringify(args[1])
+    if Acronyms:contains(acronym_key) then
+        -- The acronym exists (and is recognized)
+        return AcronymsPandoc.replaceExistingAcronym(acronym_key)
+    else
+        -- The acronym does not exists
+        return AcronymsPandoc.replaceNonExistingAcronym(acronym_key)
+    end
+end
+
+
+--[[
+    Generate the List of Acronyms in the document.
+--]]
+function generateListOfAcronyms (args, kwargs, meta)
+    if #args ~= 0 then
+        quarto.log.warning(
+            "[acronyms] Unused arguments passed to shortcode `printacronyms`:",
+            "expected 0, found", tostring(#args), "."
+        )
+    end
+
+    local header, definition_list = AcronymsPandoc.generateLoA()
+
+    if header ~= nil then
+        return { header, definition_list }
+    else
+        return definition_list
+    end
+end
+
+
+--[[
+    Define the possible shortcodes for Quarto.
+--]]
+return {
+    ["acronym"] = replaceAcronym,
+    -- Same function but with a shorter name.
+    ["acr"] = replaceAcronym,
+    ["print-acronyms"] = generateListOfAcronyms,
+}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,6 +22,7 @@ website:
       - text: Articles
         menu:
           - articles/options.qmd
+          - articles/shortcodes.qmd
           - articles/styles.qmd
       - text: Advanced usage
         menu:

--- a/docs/articles/shortcodes.qmd
+++ b/docs/articles/shortcodes.qmd
@@ -1,0 +1,250 @@
+---
+title: "Shortcodes"
+description: >
+  Learn how to use the new shortcode syntax.
+---
+
+From version 2.0.0, **acronyms** now uses the Quarto shortcode syntax (in
+addition to its legacy filter syntax).
+
+Shortcodes are clearer to use, and may have additional keyworded-arguments that
+can be used to override the behaviour described in the [options.qmd](Options)
+(which are the same for all acronyms in a given document). For example, a
+specific acronym may use a different style than the others.
+
+This article describes this new syntax, how to use the shortcodes, the
+arguments that can be used, and gives a few example.
+
+
+## The `acronym` shortcode
+
+The `{{< acronym KEY >}}` shortcode replaces an acronym in the document, where
+`KEY` identifies the acronym we want to replace (exactly as `\acr{KEY}` does
+in the legacy syntax).
+
+For convenience, the shorter `{{< acr KEY >}}` can be used instead; both will
+invoke the same function, and thus have the same arguments and behaviour.
+
+The key is mandatory, and **acronyms** will raise an error if not provided.
+In addition, the following arguments can be provided:
+
+
+### `style`
+
+This argument controls the acronym's style, that is, how it will be replaced.
+It must be used similarly to the [options.qmd#style](style option).
+Only the current acronym will use this specific style, so it is not recommended
+to provide this argument to set the same style for each acronym; prefer using
+the metadata option in this case to simplify your workload.
+
+The list of possible values can be found in the [styles.qmd](Styles) article.
+
+For example:
+
+```markdown
+---
+acronyms:
+  # Acronyms will use the long-short style by default.
+  style: long-short
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+First use (using default options): {{< acr Qmd >}}
+
+Now we force the long-long style {{< acr Qmd style=long-long >}}
+
+And now we reuse the default style: {{< acr Qmd >}}
+```
+
+
+### `first_use`
+
+In **acronyms**, most style will replace the acronym differently, based on
+whether they appear for the first time. For example, a first use may show the
+acronym longname, but only the shortname on subsequent uses.
+The `first_use` argument can be used to force the "first use" or "subsequent
+use" appearance.
+
+For example:
+
+```yaml
+---
+acronyms:
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+Forced next use: {{< acr Qmd first_use=false >}}
+```
+
+
+### `insert_links`
+
+This argument controls whether the acronym will be rendered with a link to
+its definition in the List Of Acronyms. This is similar to the
+[options.qmd#insert_links](insert_links option). As for the `style` argument,
+this only changes the current acronym behaviour; to change all acronyms, prefer
+using the option directly.
+
+For example:
+
+```markdown
+---
+acronyms:
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+{{< acr Qmd insert_links=false >}}
+```
+
+
+### `non_existing`
+
+This argument controls the behaviour when an acronym is not found. **acronyms**
+may print a warning and render it as a special token, such as `??` (like the
+BibTeX default behaviour), or raise an error, depending on the configuration.
+Like previous arguments, this one is similar to the
+[options.qmd#non_existing](non-existing option), but changes only the current
+acronym. Note that it has no impact when the acronym is found.
+
+For example:
+
+```markdown
+---
+acronyms:
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+Note that the following acronym is mis-typed: {{< acr qmd non_existing=error >}}
+```
+
+
+## The `print-acronyms` shortcode
+
+The `{{< print-acronyms >}}` shortcode can be used to generate the List Of
+Acronyms (LoA), which lists the acronyms' definitions (exactly as
+`\printacronyms` does in the legacy syntax).
+
+It is recommended to disable the automatic generation of the LoA when using
+this shortcode, to avoid duplicating the LoA in the resulting document.
+It is useful when you want to generate the LoA at some exact place.
+
+For example:
+
+```markdown
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: Qmd
+      longname: Quarto document
+---
+
+# Introduction
+
+Lorem ipsum dolor sit amet
+
+{{< print-acronyms >}}
+```
+
+The LoA can be customized by using the following keyworded arguments:
+
+
+### `sorting`
+
+This argument controls how the acronyms are sorted when printed in the LoA.
+It works similarly to the [options.qmd#sorting](sorting option). See this option
+for a list of possible behaviours and accepted values.
+
+For example:
+
+```markdown
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+    - shortname: YAML
+      longname: Yaml Ain't Markup Language
+---
+
+{{< acr Qmd >}} {{< acr YAML >}}
+
+{{< print-acronyms sorting=alphabetical >}}
+```
+
+
+### `include_unused`
+
+This argument controls whether to include the unused acronyms in the generated
+LoA. In the previous example, we had to insert the both acronyms in the document
+to make them appear in the LoA; this can be prevented by using this argument.
+
+For example:
+
+```markdown
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+    - shortname: YAML
+      longname: Yaml Ain't Markup Language
+---
+
+{{< print-acronyms include_unused=true >}}
+```
+
+
+### `title`
+
+This argument controls the title of the generated LoA, similarly to the
+[options.qmd#loa_title](loa_title option). When using a shortcode, you will
+most likely want to disable this title, and specify the header exactly as
+you want directly in the document.
+
+For example:
+
+```markdown
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+# My custom title
+
+{{< print-acronyms title="" >}}
+```
+
+
+### `header_classes`
+
+This argument controls the additional classes that are set to the LoA title,
+similarly to the [options.qmd#loa_header_classes](loa_header_classes options).
+Note that it has no impact when the LoA title is not generated.
+
+For example:
+
+```markdown
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: Qmd
+      longname: Quarto documents
+---
+
+{{< print-acronyms header_classes=.unnumbered >}}
+```

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -6,6 +6,9 @@
 # The only difference it makes is when setting the page's title, which
 # appears in the tab. But, for a homepage, simply having the website's title
 # is good enough.
+
+# We also specify that the input markdown contains emojis.
+from: markdown+emoji
 ---
 
 {{< include ../README.md >}}

--- a/example.qmd
+++ b/example.qmd
@@ -26,3 +26,5 @@ acronyms:
 This paragraph mentions \acr{RL} for the first time.
 
 And now, in this paragraph, \acr{RL} is in short form.
+
+Using a shortcode: {{< acr RL >}}.

--- a/notes
+++ b/notes
@@ -1,0 +1,44 @@
+# Docs
+
+- Maybe we can specify the version next to the title?
+  + Pre-render script to read the version from the extension's YAML config file
+  + Should we put it directly in the title or in a new field?
+    We need to change the template if we want a new field. Apply some CSS...
+
+- Maybe create an icon / logo
+
+- Perhaps build the example in the documentation website
+  + Include the source code with https://github.com/pandoc/lua-filters/tree/master/include-code-files?
+  + Difficult to build the example because we do not have access to the acronyms
+    extension.
+
+- Enlever `quarto publish`, faire un `render` puis utiliser les actions GitHub
+  pour faire un artéfact et déployer les Pages. `publish` requiert de push
+  sur la branche `gh-pages`, ce qui déclenche un autre workflow pour build et
+  déployer... (donc branche additionnelle + workflow additionnel).
+
+# Features
+
+- Shortcodes
+
+- Books
+  Maybe we can support books by adding a `loa_on_different_page` option?
+  If the option is set to `false` or `nil`, we assume that the LoA is on the same
+    page.
+  Otherwise, we must build a link to the specified page, e.g., `[loa.qmd#acr1]`.
+  Check first that such manually-built links do work!!
+
+# Bugfixes
+
+-- We want to require the Lua files which are in the same folder.
+-- However, as we are invoking this file through Quarto, we do not have control
+-- over the `LUA_PATH` environment variable, nor the current working directory.
+-- It seems to me that we need to add this current file's directory
+-- to the list of searched directories, i.e., `package.path`.
+local current_dir = debug.getinfo(1).source:match("@?(.*/)")
+package.path = package.path .. ";" .. current_dir .. "/?.lua"
+
+- FIX THE PREVIEW_STYLE !!
+
+- Fix the docs
+  "See [external_file.qmd] for a detailed explanation" in multi_document.qmd

--- a/tests/22-shortcode-simple/Readme.md
+++ b/tests/22-shortcode-simple/Readme.md
@@ -1,0 +1,3 @@
+This file demonstrates a simple usage of shortcodes in **acronyms**.
+
+Shortcodes are an alternative to the previous filter-based markup.

--- a/tests/22-shortcode-simple/expected.md
+++ b/tests/22-shortcode-simple/expected.md
@@ -1,0 +1,10 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And now, in this paragraph, [RL](#acronyms_RL) is in short form.

--- a/tests/22-shortcode-simple/input.qmd
+++ b/tests/22-shortcode-simple/input.qmd
@@ -1,0 +1,12 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+---
+
+# Introduction {#intro}
+
+This paragraph mentions {{< acr RL >}} for the first time.
+
+And now, in this paragraph, {{< acr RL >}} is in short form.

--- a/tests/23-shortcode-specific-style/Readme.md
+++ b/tests/23-shortcode-specific-style/Readme.md
@@ -1,0 +1,3 @@
+This file demonstrates how to specify the style when using shortcodes.
+
+This allows mixing various styles in the same document.

--- a/tests/23-shortcode-specific-style/expected.md
+++ b/tests/23-shortcode-specific-style/expected.md
@@ -1,0 +1,12 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning
+
+# Introduction {#intro}
+
+[Reinforcement Learning (RL)](#acronyms_RL) should be in long form, using default style.
+
+And now, [RL](#acronyms_RL) is in short form, using the default style again.
+
+Here, [Reinforcement Learning](#acronyms_RL) uses the `long-long` style.

--- a/tests/23-shortcode-specific-style/input.qmd
+++ b/tests/23-shortcode-specific-style/input.qmd
@@ -1,0 +1,15 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+  style: long-short
+---
+
+# Introduction {#intro}
+
+{{< acr RL >}} should be in long form, using default style.
+
+And now, {{< acr RL >}} is in short form, using the default style again.
+
+Here, {{< acr RL style=long-long >}} uses the `long-long` style.

--- a/tests/24-shortcode-listofacronyms/Readme.md
+++ b/tests/24-shortcode-listofacronyms/Readme.md
@@ -1,0 +1,6 @@
+This test demonstrates how to generate the List of Acronyms with a shortcode.
+
+This shortcode can be placed anywhere in the document. It is recommended to set
+the `insert_loa` option to `false`, in order to avoid automatically generating
+a List of Acronyms at the beginning of the document, when using the
+`{{< printacronyms >}}` shortcode.

--- a/tests/24-shortcode-listofacronyms/expected.md
+++ b/tests/24-shortcode-listofacronyms/expected.md
@@ -1,0 +1,10 @@
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And now, in this paragraph, [RL](#acronyms_RL) is in short form.
+
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning

--- a/tests/24-shortcode-listofacronyms/input.qmd
+++ b/tests/24-shortcode-listofacronyms/input.qmd
@@ -1,0 +1,15 @@
+---
+acronyms:
+  insert_loa: false
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+---
+
+# Introduction {#intro}
+
+This paragraph mentions {{< acr RL >}} for the first time.
+
+And now, in this paragraph, {{< acr RL >}} is in short form.
+
+{{< print-acronyms >}}

--- a/tests/run_tests.ts
+++ b/tests/run_tests.ts
@@ -342,6 +342,10 @@ const testDirs = [
     '18-sorting-initial',
     '19-sorting-usage',
     '20-sorting-alphabetical-case-insensitive',
+    '21-loa-unnumbered-section',
+    '22-shortcode-simple',
+    '23-shortcode-specific-style',
+    '24-shortcode-listofacronyms',
 ];
 
 


### PR DESCRIPTION
Added support for Quarto *shortcodes*, a different syntax (`{{< acr KEY >}}`) than the legacy one, inherited from filters.

* This syntax is less error-prone, as it directly uses Quarto features, rather than trying to regex-find an arbitrary string in the document.
* It also natively supports arguments and keyworded arguments (whereas our custom syntax would have been difficult to extend), which means that we can more finely control the behaviour of individual acronyms and list of acronyms.