### PR TITLE
Add support for translations

### DIFF
--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -10,6 +10,13 @@ This file defines the Options table.
 -- (parse them from configuration files, get them, ...).
 local Options = {
 
+    -- The language used in this document (Quarto standard option), following
+    -- the IETF BCP47 standard, i.e., a tag composed of subtags, separated by
+    -- hyphens (`-`). For example: `en-US`. The first subtag represent the
+    -- language itself (`en`, `fr`, `zh`, ...), other subtags represent
+    -- more precise information (region, script, ...).
+    lang = "",
+
     -- The prefix to prepend to all acronym's ID (to ensure their uniqueness).
     -- IDs are especially used to link an acronym to its definition in the List
     -- of Acronyms.
@@ -53,6 +60,11 @@ Parse the options from the Metadata (i.e., the YAML fields).
 --]]
 function Options:parseOptionsFromMetadata(m)
     quarto.log.debug("[acronyms] Parsing options from metadata...", m.acronyms)
+    -- Load the lang (can be `nil`); this is the only option outside `acronyms`.
+    if m.lang ~= nil then
+        self.lang = pandoc.utils.stringify(m.lang)
+    end
+
     -- The options that we are interested in are all grouped under `acronyms`.
     -- If it does not exist, use an empty table.
     options = m.acronyms or {}

--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -27,7 +27,7 @@ local Options = {
     sorting = "alphabetical",
 
     -- The title (header) that precedes the List of Acronyms (LoA).
-    loa_title = pandoc.MetaInlines(pandoc.Str("List Of Acronyms")),
+    loa_title = nil,
 
     -- Whether to include in the LoA acronyms that have not been used.
     include_unused = true,

--- a/_extensions/acronyms/acronyms_pandoc.lua
+++ b/_extensions/acronyms/acronyms_pandoc.lua
@@ -32,6 +32,9 @@ local replaceExistingAcronymWithStyle = require("acronyms_styles")
 -- The options for the List Of Acronyms, as defined in the document's metadata.
 local Options = require("acronyms_options")
 
+-- The translations for some hardcoded sentences (such as the LoA Title)
+local Translations = require("acronyms_translations")
+
 -- The functions that we define here, and which will generate Pandoc elements
 local AcronymsPandoc = {}
 
@@ -133,7 +136,17 @@ function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_class
     -- Use default options if not specified
     sorting = sorting or Options["sorting"]
     include_unused = include_unused or Options["include_unused"]
-    title = title or Options["loa_title"]
+    if title == nil then
+        -- No shortcode-specific value given
+        if Options["loa_title"] ~= nil then
+            -- A value given in the metadata (options)
+            title = Options["loa_title"]
+        else
+            -- If neither the metadata nor the shortcode option are specified,
+            -- by default we use the translation for the user's language
+            title = pandoc.MetaInlines(pandoc.Str(Translations:get_loa_title(Options["lang"])))
+        end
+    end
     header_classes = header_classes or Options["loa_header_classes"]
 
     -- We first get the list of sorted acronyms, according to the defined criteria.

--- a/_extensions/acronyms/acronyms_translations.lua
+++ b/_extensions/acronyms/acronyms_translations.lua
@@ -1,0 +1,75 @@
+--[[
+    Functions to translate some (hardcoded) sentences to the language
+    that is both available and closest to the user's preference.
+
+    Matching algorithm in this file are based on RFC4647; languages are
+    based on RFC5646 (see Quarto's documentation about the `lang` option).
+--]]
+
+
+local Translations = {
+    -- Add custom translations here.
+    -- Each table refers to one given "sentence" to translate.
+    -- The table's contents must be the translations, indexed by a language.
+    -- Languages can be specified using subtags, for example, `en-GB` or `en-US`.
+    loa_title = {
+        [""] = "List Of Acronyms", -- Default value
+        ["en"] = "List Of Acronyms",
+        ["fr"] = "Liste des Acronymes",
+    }
+}
+
+
+-- Simplified Lookup, based on RFC4647; does not explicitly support private
+-- subtags (`x-...`) but they should not be used in Quarto anyway.
+-- `lang` must be the user's preferred language range (e.g., `zh-Hant-CN`).
+-- `translations` must be a table, indexed by language tags.
+-- Returns a table { lang, translation }, where `lang` is the closest language
+-- found, and `translation` is the desired string in the found language.
+function Translations:find_best(lang, translations)
+    quarto.log.debug("[acronyms] Request translation for ", lang)
+
+    -- We will need to iterate over the subtags; for example, for `zh-Hant-CN`,
+    -- it should yield `zh-Hant-CN`, then `zh-Hant`, then `zh` (and finally ``).
+    -- This loop populates the table with `{ "", "zh", "zh-Hant", "zh-Hant-CN" }`.
+    local lang_components = {""}
+    local previous = ""
+    for component in string.gmatch(lang, "[^-]+") do
+        if previous == "" then
+            previous = component
+        else
+            previous = previous .. "-" .. component
+        end
+        table.insert(lang_components, previous)
+    end
+
+    -- Now, we iterate over the (reversed) table, because we want to start with
+    -- the most specific lang. If this lang is found, we return it immediately.
+    for i = #lang_components, 1, -1 do
+        if translations[lang_components[i]] ~= nil then
+            local found_lang = lang_components[i]
+            local found_translation = translations[lang_components[i]]
+            quarto.log.debug("[acronyms] Found translation ", found_translation,
+                " for lang ", found_lang)
+            return {
+                ["lang"] = found_lang,
+                ["translation"] = found_translation
+            }
+        end
+    end
+    return nil
+end
+
+function Translations:get_loa_title(lang)
+    local found = self:find_best(lang, self.loa_title)
+    if found == nil then
+        quarto.log.error(
+            "[acronyms] Could not find a suitable translation for ", lang, "!",
+            "Please ensure that a default translation is available for loa_title"
+        )
+        assert(false)
+    end
+    return found["translation"]
+end
+
+return Translations

--- a/docs/articles/options.qmd
+++ b/docs/articles/options.qmd
@@ -17,6 +17,7 @@ along with their default values.
 
 ```yaml
 ---
+lang: en
 acronyms:
   loa_title: "List of Acronyms"
   loa_header_classes: []
@@ -31,6 +32,15 @@ acronyms:
     - ./acronyms.yml
 ---
 ```
+
+## `lang`
+
+This is a [standard Quarto option](https://quarto.org/docs/authoring/language.html)
+that sets the document language. When specified, **acronyms** automatically
+recognizes it, and translates some elements, such as the List of Acronyms' title.
+By default, if the translation is not available for your language, it will
+resort to English. If you are not satisfied with this title, you can always
+override it manually by using the [`loa_title`](#loa_title) option.
 
 
 ## `loa_title`

--- a/tests/28-translation/expected.md
+++ b/tests/28-translation/expected.md
@@ -1,0 +1,10 @@
+# Liste des Acronymes {#acronyms_HEADER_LOA .loa}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And now, in this paragraph, [RL](#acronyms_RL) is in short form.

--- a/tests/28-translation/input.qmd
+++ b/tests/28-translation/input.qmd
@@ -1,0 +1,13 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+lang: fr
+---
+
+# Introduction {#intro}
+
+This paragraph mentions \acr{RL} for the first time.
+
+And now, in this paragraph, \acr{RL} is in short form.

--- a/tests/run_tests.ts
+++ b/tests/run_tests.ts
@@ -349,6 +349,7 @@ const testDirs = [
     '25-shortcode-firstuse',
     '26-shortcode-insertlinks',
     '27-shortcode-nonexisting',
+    '28-translation',
 ];
 
 


### PR DESCRIPTION
This PR adds the `Translations` module, which can be used to provide different translations of a given sentence, in various languages.

In particular, it allows translating the "List Of Acronyms" title.
Closes #20