### PR TITLE
Add option to customize the List Of Acronyms format

### DIFF
--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -52,6 +52,10 @@ local Options = {
     -- Additional classes to add to the List of Acronyms header.
     loa_header_classes = {},
 
+    -- Custom format for the List of Acronyms, as a Markdown template in which
+    -- the `{shortname}` and `{longname}` placeholders will be replaced.
+    loa_format = nil,
+
 }
 
 
@@ -126,6 +130,14 @@ function Options:parseOptionsFromMetadata(m)
     if options["loa_header_classes"] ~= nil then
         for _, v in ipairs(options["loa_header_classes"]) do
             table.insert(self.loa_header_classes, pandoc.utils.stringify(v))
+        end
+    end
+
+    if options["loa_format"] ~= nil then
+        if pandoc.utils.type(options["loa_format"]) == "Inlines" then
+            self.loa_format = options["loa_format"][1].text
+        else
+            self.loa_format = pandoc.utils.stringify(options["loa_format"])
         end
     end
 end

--- a/docs/articles/options.qmd
+++ b/docs/articles/options.qmd
@@ -21,6 +21,7 @@ lang: en
 acronyms:
   loa_title: "List of Acronyms"
   loa_header_classes: []
+  loa_format: nil
   include_unused: true
   insert_loa: "beginning"
   insert_links: true
@@ -98,6 +99,39 @@ acronyms:
     - unnumbered
 ---
 ```
+
+
+## `loa_format`
+
+This option controls how to render the List of Acronyms (LoA). By default,
+it is rendered as a Definition List, which prints the acronym's shortname on
+a first line, and the acronym's definition on a second line, indented.
+
+When rendering a HTML document, the Definition List can be stylized using CSS;
+but it is not easy on other formats (PDF, DOCX, ...). To override this behaviour,
+the `loa_format` allows you to specify a Markdown template to render each
+acronym in the LoA. The template may contain Markdown syntax, such as `**`
+for bold font, `*` for italic, etc. The template should also contain the
+`{shortname}` and `{longname}` placeholders, which **acronyms** will replace
+by each acronym's short name and long name.
+
+Note that, because this string can use Markdown syntax, it must be suffixed
+with the `{=raw}` qualifier to avoid Markdown being parsed too early.
+
+Examples:
+
+To render acronyms to a bullet list, with the short name in bold font, followed
+by a colon, then the long name on the same line:
+
+```yaml
+---
+acronyms:
+  loa_format: '`- **{shortname}**: {longname}`{=raw}'
+---
+```
+
+In this example, `- **{shortname}**: {longname}` is the template itself.
+The `{=raw}` part is unfortunately needed to avoid bugs with Pandoc.
 
 
 ## `include_unused`

--- a/tests/29-custom-loa-format/expected.md
+++ b/tests/29-custom-loa-format/expected.md
@@ -1,0 +1,11 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+-   **[Qmd]{#acronyms_Qmd}**: Quarto document
+
+-   **[RL]{#acronyms_RL}**: Reinforcement Learning
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And here, [Quarto document (Qmd)](#acronyms_Qmd) is mentioned.

--- a/tests/29-custom-loa-format/input.qmd
+++ b/tests/29-custom-loa-format/input.qmd
@@ -1,0 +1,15 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+    - shortname: Qmd
+      longname: Quarto document
+  loa_format: '`- **{shortname}**: {longname}`{=raw}'
+---
+
+# Introduction {#intro}
+
+This paragraph mentions \acr{RL} for the first time.
+
+And here, \acr{Qmd} is mentioned.


### PR DESCRIPTION
The List Of Acronyms (LoA) was previously rendered as a Definition List, which can be stylized in HTML/CSS, but not when using other output formats (PDF, DOCX, ...).

This PR:

* adds a new `loa_format` option to customize how the LoA is rendered;
* refactors the way we generate the LoA, to use this new option, resorting to Definition List as a default;
* adds a test to ensure the custom format works;
* updates the documentation accordingly.

Solves #19 