### PR TITLE
Fix option to customize the LoA format

### DIFF
--- a/tests/29-custom-loa-format/expected.md
+++ b/tests/29-custom-loa-format/expected.md
@@ -1,8 +1,12 @@
 # List Of Acronyms {#acronyms_HEADER_LOA .loa}
 
+<div>
+
 -   **[Qmd]{#acronyms_Qmd}**: Quarto document
 
 -   **[RL]{#acronyms_RL}**: Reinforcement Learning
+
+</div>
 
 # Introduction {#intro}
 

--- a/tests/30-custom-loa-format-multiple-blocks/expected.md
+++ b/tests/30-custom-loa-format-multiple-blocks/expected.md
@@ -1,0 +1,15 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+<div>
+
+**[Qmd]{#acronyms_Qmd}**: Quarto document
+
+**[RL]{#acronyms_RL}**: Reinforcement Learning
+
+</div>
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And here, [Quarto document (Qmd)](#acronyms_Qmd) is mentioned.

--- a/tests/30-custom-loa-format-multiple-blocks/input.qmd
+++ b/tests/30-custom-loa-format-multiple-blocks/input.qmd
@@ -1,0 +1,15 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+    - shortname: Qmd
+      longname: Quarto document
+  loa_format: '`**{shortname}**: {longname}`{=raw}'
+---
+
+# Introduction {#intro}
+
+This paragraph mentions \acr{RL} for the first time.
+
+And here, \acr{Qmd} is mentioned.


### PR DESCRIPTION
The option implemented in the previous PR #24 was not working correctly for some templates that render to several "blocks".

Using a bullet list, such as: `- **{shortname}**: {longname}` was fine, because a bullet list counts as a single block.
The same template, without the bullet point (`**{shortname}**: {longname}`) did not work any more, because it generates several blocks in Pandoc.

The fix should work for most templates, although it requires wrapping the result in a Div, which changes the result.
When generating a bullet list, it might be seen as unnecessary, because it is already a single block in itself; yet, it should be our safest way to handle all templates.