### PR TITLE
Non alpha characters

### DIFF
--- a/_extensions/acronyms/acronyms_helpers.lua
+++ b/_extensions/acronyms/acronyms_helpers.lua
@@ -52,7 +52,9 @@ end
 -- Helper function to generate the ID (identifier) from an acronym key.
 -- The ID can be used for, e.g., links.
 function Helpers.key_to_id(key)
-    return Options["id_prefix"] .. key
+    -- Sanitize the key, i.e., replace non-ASCII characters with `-`
+    local sanitized_key = string.gsub(key, "[^0-9A-Za-z]", "_")
+    return Options["id_prefix"] .. sanitized_key
 end
 
 

--- a/tests/31-non-alphanum-characters/Readme.md
+++ b/tests/31-non-alphanum-characters/Readme.md
@@ -1,0 +1,14 @@
+This test ensures that non-alpha-numerical characters can be used as part of
+acronyms (both shortnames and longnames).
+
+Shortnames are especially important to check because they are converted to
+- the acronym's key if is not specified;
+- the acronym's ID, which is used in links to the List Of Acronyms.
+
+The key should not be a problem, except perhaps in shortcodes? It should
+not contain any spaces. But the key can be specified on its own if something
+other than the shortname must be used anyway.
+
+The link ID is a bigger problem: it is used to create an anchor, which
+only accept some valid characters. This test ensures that a proper sanitization
+happens and that anchors still work despite the non-alpha-numerical characters.

--- a/tests/31-non-alphanum-characters/expected.md
+++ b/tests/31-non-alphanum-characters/expected.md
@@ -1,0 +1,21 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[CL/F]{#acronyms_CL_F}
+:   Test with a /
+
+[Cav,ss]{#acronyms_Cav_ss}
+:   Test with a ,
+
+[Thé]{#acronyms_Th__}
+:   Test with accents
+
+[漢字]{#acronyms_______}
+:   Test with kanjis
+
+# Introduction {#intro}
+
+Shortnames with special characters are OK: [Test with a / (CL/F)](#acronyms_CL_F) ; [Test with a , (Cav,ss)](#acronyms_Cav_ss)
+
+Also those with accents (but please avoid using only accents): [Test with accents (Thé)](#acronyms_Th__)
+
+Same for Kanjis: [Test with kanjis (漢字)](#acronyms_______)

--- a/tests/31-non-alphanum-characters/input.qmd
+++ b/tests/31-non-alphanum-characters/input.qmd
@@ -1,0 +1,20 @@
+---
+acronyms:
+  keys:
+    - shortname: CL/F
+      longname: Test with a /
+    - shortname: Cav,ss
+      longname: Test with a ,
+    - shortname: Thé
+      longname: Test with accents
+    - shortname: 漢字
+      longname: Test with kanjis
+---
+
+# Introduction {#intro}
+
+Shortnames with special characters are OK: \acr{CL/F} ; \acr{Cav,ss}
+
+Also those with accents (but please avoid using only accents): \acr{Thé}
+
+Same for Kanjis: \acr{漢字}


### PR DESCRIPTION
Add support for non-alphanumerical characters in shortnames, by sanitizing the key when creating an anchor.

This bug was highlighted by #31 