### PR TITLE
Simplified format for `fromfile` external documents

### DIFF
--- a/tests/32-simplified-external-format/Readme.md
+++ b/tests/32-simplified-external-format/Readme.md
@@ -1,0 +1,6 @@
+This test demonstrates the "simplified" format for the `fromfile` documents
+that allow to define acronyms in a separate YAML file.
+
+The test includes both the original format (in `acronyms_original.yml`)
+and the simplified format (in `acronyms_simplified.yml`) to ensure that
+both formats are supported: no breaking changes must appear.

--- a/tests/32-simplified-external-format/acronyms_original.yml
+++ b/tests/32-simplified-external-format/acronyms_original.yml
@@ -1,0 +1,6 @@
+---
+acronyms:
+  keys:
+    - shortname: RL
+      longname: Reinforcement Learning
+---

--- a/tests/32-simplified-external-format/acronyms_simplified.yml
+++ b/tests/32-simplified-external-format/acronyms_simplified.yml
@@ -1,0 +1,3 @@
+---
+YAML: YAML Ain't Markup Language
+---

--- a/tests/32-simplified-external-format/expected.md
+++ b/tests/32-simplified-external-format/expected.md
@@ -1,0 +1,13 @@
+# List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[RL]{#acronyms_RL}
+:   Reinforcement Learning
+
+[YAML]{#acronyms_YAML}
+:   YAML Ain't Markup Language
+
+# Introduction {#intro}
+
+This paragraph mentions [Reinforcement Learning (RL)](#acronyms_RL) for the first time.
+
+And this paragraph mentions [YAML Ain't Markup Language (YAML)](#acronyms_YAML).

--- a/tests/32-simplified-external-format/input.qmd
+++ b/tests/32-simplified-external-format/input.qmd
@@ -1,0 +1,14 @@
+---
+acronyms:
+  fromfile:
+    # The first file uses the "original" (verbose!) format.
+    - ./acronyms_original.yml
+    # The second file uses a simplified format, faster and easier to write.
+    - ./acronyms_simplified.yml
+---
+
+# Introduction {#intro}
+
+This paragraph mentions \acr{RL} for the first time.
+
+And this paragraph mentions \acr{YAML}.


### PR DESCRIPTION
This PR allows using a simplified format for acronyms defined in external (`fromfile`) documents, as discussed in #33 

Example:

```md
---
qmd: Quarto document
YAML: YAML Ain't Markup Language
---
```

This new feature retains compatibility with previous versions; files may use either the original (verbose) format, or the new simplified one.