### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ provided the same features, but for [RMarkdown][rmarkdown] documents.
     [specified](https://rchaput.github.io/acronyms/articles/options.html#insert_loa)
     (by default, at the beginning of the document).
 - Automatic sorting of this list.
-+ You can choose between the *alphabetical*, *usage* or *initial*
-  [order](https://rchaput.github.io/acronyms/articles/options.html#sorting).
+  + You can choose between the *alphabetical*, *usage* or *initial*
+    [order](https://rchaput.github.io/acronyms/articles/options.html#sorting).
 - Easily manage acronyms
   + Choose between multiple [styles](https://rchaput.github.io/acronyms/articles/styles.html)
     to replace acronyms.

--- a/docs/advanced/customized_loa_header.qmd
+++ b/docs/advanced/customized_loa_header.qmd
@@ -38,7 +38,8 @@ Using an acronym: \acr{qmd}
 This will generate a PDF with sections `List of Acronyms` (unnumbered), and
 `1. Introduction` (numbered). Note that the List of Acronyms is, by default,
 generated at the beginning of the document, but you may customize it to put
-at the end, or even at your desired location, by using the [options].
+at the end, or even at your desired location, by using the
+[options](../articles/options.qmd).
 
 
 ## Manually customizing the title
@@ -47,9 +48,10 @@ You may also want to fully customize the header of the List of Acronyms; this
 can be done by disabling the automatic generation, and then writing your
 own header, for which you can leverage all Pandoc and Quarto features.
 
-To do so, simply set the [insert_loa] option to `false` to disable the
-automatic generation of the List of Acronyms, and set [loa_title] to `''` (the
-empty string) to disable the generation of the header.
+To do so, simply set the [insert_loa](../articles/options.qmd#insert_loa) 
+option to `false` to disable the automatic generation of the List of Acronyms, 
+and set [loa_title](../articles/options.qmd#loa_title) to `''` (the empty 
+string) to disable the generation of the header.
 You may then write exactly what you want as a header, and use `\printacronyms`
 to generate the List of Acronyms after your header.
 
@@ -77,7 +79,3 @@ Using an acronym: \acr{qmd}
 
 At the end of the document
 ```
-
-[options]: ../articles/options.qmd
-[loa_title]: ../articles/options.qmd#loa_title
-[insert_loa]: ../articles/options.qmd#insert_loa

--- a/docs/getting_started.qmd
+++ b/docs/getting_started.qmd
@@ -5,7 +5,8 @@ description: >
 ---
 
 The goal of **acronyms** is to provide support for acronyms to Quarto
-documents, in a similar way to what [glossaries] achieve for LaTeX.
+documents, in a similar way to what
+[glossaries](https://www.ctan.org/pkg/glossaries) achieve for LaTeX.
 
 Basically, it allows you to define a list of acronyms, and to automatically
 replace acronyms inside the document.
@@ -78,16 +79,16 @@ Finally, to insert an acronym into the document, simply use `\acr{<KEY>}`,
 where `<KEY>` is an acronym's key, as defined in the YAML metadata.
 
 This command will be automatically replaced by **acronyms**. The result
-depends on the chosen style (see [styles] for more details). Most
-styles will also make a difference between the first use, and the next
-occurrences.
+depends on the chosen style (see [styles](articles/styles.qmd) for more 
+details). Most styles will also make a difference between the first use, and 
+the next occurrences.
 
-By default, **acronymsdown** will replace as follows:
+By default, **acronyms** will replace as follows:
 
 - first use: `<long name> (<short name>)`
 - next uses: `<short name>`
 
-The next lines show an example of how **acronymsdown** replaces acronyms
+The next lines show an example of how **acronyms** replaces acronyms
 in a document, assuming the acronyms `qmd` and `yaml` have been defined, as
 per the previous example.
 
@@ -100,13 +101,13 @@ for the metadata.
 > YAML Ain't Markup Language (YAML) for the metadata.
 
 Notice how by using `\acrs` we can pluralize the acronym; you can read more
-about that in [Plural form][plural].
+about that in [Plural form](articles/plural.qmd).
 
 
 ## Complete example
 
 A complete example showing the previous instructions as a single file can
-be found [here][example].
+be found [here](https://github.com/rchaput/acronyms/blob/master/example.qmd).
 
 
 ## Next steps
@@ -116,17 +117,11 @@ The current vignette gives you the tools for a simple document, using the
 However, most of the mechanisms are highly configurable and offer various
 options.
 
-Available options are described in [Options][options], and several tutorials
-for advanced usages are listed in [Advanced usage][advanced_usage].
+Available options are described in [Options](articles/options.qmd), and several
+tutorials for advanced usages are listed in [Advanced usage](advanced/index.qmd).
 
-[Styles][styles] lists the different styles that can be used, along
-with a small example to visualize each of them.
+You can also read more about the new [shortcode](articles/shortcodes.qmd)
+syntax.
 
-
-[glossaries]: https://www.ctan.org/pkg/glossaries
-[Lua Filter]: https://pandoc.org/lua-filters.html
-[styles]: articles/styles.qmd
-[example]: https://github.com/rchaput/acronyms/blob/master/example.qmd
-[advanced_usage]: advanced/index.qmd
-[options]: articles/options.qmd
-[plural]: articles/plural.qmd
+[Styles](articles/styles.qmd) lists the different styles that can be used,
+along with a small example to visualize each of them.


### PR DESCRIPTION
- Fixed the alignment of a list item in the README.
- Replaced `acronymsdown` with `acronyms` in getting_started.
- Changed the way we refer to links, by using links directly in-document, and avoiding specifying links at the end of file whenever possible.
- Adding a short paragraph about shortcodes in getting_started.