### PR TITLE
Improve tests with previous Quarto releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,18 @@ jobs:
       matrix:
         quarto_version: [release]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # Additionally, we want to run the `pre-release` version for Ubuntu
+        # Additionally, we want to run the `pre-release` version for Ubuntu;
+        # and older versions to check that they still work.
+        # Quarto requires the complete version number, e.g., 1.4 would not work.
         include:
           - os: ubuntu-latest
             quarto_version: pre-release
+          - os: ubuntu-latest
+            quarto_version: 1.4.557
+          - os: ubuntu-latest
+            quarto_version: 1.5.57
+          - os: ubuntu-latest
+            quarto_version: 1.6.43
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The automatic tests workflow used the `release` (for macOS, Windows, and Ubuntu)  and `pre-relase` (only for Ubuntu) versions of Quarto, which allows to check that the extension works on the current version and the future one. But it was not sufficient: as time goes on, more Quarto versions are released; we claim in `_extensions/acronyms/_extension.yml` that we are compatible with Quarto >= 1.4.0. Because the `release` is now 1.7, we no longer test with versions 1.4, 1.5, and 1.6.

This commit adds such versions to the automatic tests. Quarto requires a full version number, and we thus chose the latest one from each "minor" (assuming major.minor.patch).