### PR TITLE
Fix misleading documentation of shortcodes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ acronyms:
 
 `\acr{qmd} can be used to write technical content. \acr{qmd} use \acr{YAML}.`
 
-or the newer shortcode syntax `{{{< acr KEY >}}}`:
+or the newer shortcode syntax :
 
-`{{{< acr qmd >}}} can be used to write technical content. {{{< acr qmd >}}} use {{{< acr YAML >}}}.`
+```{shortcodes=false}
+{{< acr KEY >}}
+```
+
+```{shortcodes=false}
+{{< acr qmd >}} can be used to write technical content. {{< acr qmd >}} use {{< acr YAML >}}.
+```
 
 Both syntaxes render as (using default options):
 


### PR DESCRIPTION
As mentioned in #39, the README uses the wrong syntax for shortcodes (with 3 braces instead of 2). This was because the README is directly included in the documentation website (using `{{< include >}}`), and Quarto would thus try to render the shortcodes, making them disappear. In the built documentation, the 3-braces shortcodes would appear as the correct 2-braces version, because they were processed by Quarto.

However, when read on GitHub, the README would show the incorrect 3-braces version, which was misleading to users.
Using a code block with the special attribute `{shortcodes=false}` seems to work: on GitHub, it is rendered as a code block, and the attribute is ignored, although valid Markdown. In the build docs, Quarto recognizes the attribute, ignores the shortcodes, and renders it as a code block as well. Even users that would read the README source code would see the correct syntax.