### PR TITLE
Add support for commands/shortcodes sentence-capitalizing long form

### DIFF
--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -144,7 +144,7 @@ Replace each `\acr{KEY}` (or `\acr[opt]{KEY}`) with the correct text and link to
 --]]
 function replaceAcronym(el)
     -- Match \acr{key}, \acrs{key}, or with an option: \acr[opt]{key}, \acrs[opt]{key}
-    local command, opts_str, acr_key = string.match(el.text, "\\([Aa]crs?)%[?(.-)%]?{(.+)}")
+    local command, opts_str, acr_key = string.match(el.text, "\\([Aa][cC][rR][sS]?)%[?(.-)%]?{(.+)}")
 
     if acr_key then
         -- This is an acronym, we need to parse it.
@@ -164,17 +164,17 @@ function replaceAcronym(el)
               is_first_use = Helpers.str_to_boolean(opts.first_use)
             end
 
-            local plural = (command:sub(-1) == "s")
+            local plural = (command:sub(-1) == "s") or (command:sub(-1) == "S")
                     or (opts.plural == "true" or opts.plural == true)
 
-            local case_target
+            local case_target = opts.case_target
             local case
-            if command:sub(1, 1) == 'A' then
+            if command:sub(1, 3) == "Acr" then
                 case = "sentence"
-                case_target = "long"
-            else 
+            elseif command:sub(1, 3) == "ACR" then
+                case = "upper"
+            else
                 case = opts.case
-                case = opts.case_target
             end
 
             return AcronymsPandoc.replaceExistingAcronym(

--- a/_extensions/acronyms/parse-acronyms.lua
+++ b/_extensions/acronyms/parse-acronyms.lua
@@ -144,7 +144,7 @@ Replace each `\acr{KEY}` (or `\acr[opt]{KEY}`) with the correct text and link to
 --]]
 function replaceAcronym(el)
     -- Match \acr{key}, \acrs{key}, or with an option: \acr[opt]{key}, \acrs[opt]{key}
-    local command, opts_str, acr_key = string.match(el.text, "\\(acrs?)%[?(.-)%]?{(.+)}")
+    local command, opts_str, acr_key = string.match(el.text, "\\([Aa]crs?)%[?(.-)%]?{(.+)}")
 
     if acr_key then
         -- This is an acronym, we need to parse it.
@@ -167,9 +167,15 @@ function replaceAcronym(el)
             local plural = (command:sub(-1) == "s")
                     or (opts.plural == "true" or opts.plural == true)
 
-            local case_target = opts.case_target
-
-            local case = opts.case
+            local case_target
+            local case
+            if command:sub(1, 1) == 'A' then
+                case = "sentence"
+                case_target = "long"
+            else 
+                case = opts.case
+                case = opts.case_target
+            end
 
             return AcronymsPandoc.replaceExistingAcronym(
                 acr_key, style, is_first_use, insert_links, plural, case_target, case

--- a/_extensions/acronyms/shortcodes_acronyms.lua
+++ b/_extensions/acronyms/shortcodes_acronyms.lua
@@ -171,7 +171,27 @@ return {
     ["acr"] = replaceAcronym,
     -- A few shortcuts (variations of the shortcode name that enable
     -- default options, such as case and plural).
+    ["acronyms"] = replaceAcronymWithDefaultValues({ ["plural"] = true }),
+    ["acrs"] = replaceAcronymWithDefaultValues({ ["plural"] = true }),
     ["Acronym"] = replaceAcronymWithDefaultValues({ ["case"] = "sentence" }),
     ["Acr"] = replaceAcronymWithDefaultValues({ ["case"] = "sentence" }),
+    ["Acronyms"] = replaceAcronymWithDefaultValues({
+        ["case"] = "sentence",
+        ["plural"] = true,
+    }),
+    ["Acrs"] = replaceAcronymWithDefaultValues({ 
+        ["case"] = "sentence",
+        ["plural"] = true,
+    }),
+    ["ACRONYM"] = replaceAcronymWithDefaultValues({ ["case"] = "upper" }),
+    ["ACR"] = replaceAcronymWithDefaultValues({ ["case"] = "upper" }),
+    ["ACRONYMS"] = replaceAcronymWithDefaultValues({
+        ["case"] = "upper",
+        ["plural"] = true,
+    }),
+    ["ACRS"] = replaceAcronymWithDefaultValues({
+        ["case"] = "upper",
+        ["plural"] = true,
+    }),
     ["print-acronyms"] = generateListOfAcronyms,
 }

--- a/_extensions/acronyms/shortcodes_acronyms.lua
+++ b/_extensions/acronyms/shortcodes_acronyms.lua
@@ -109,11 +109,26 @@ end
 --[[
     Wrapper for sentence case acronyms
 ]]--
-function replaceAcronymSentenceCase (args, kwargs, meta)
-    kwargs['case'] = 'sentence'
-    kwargs['case_target'] = 'long'
-    return replaceAcronym(args, kwargs, meta)
+-- function replaceAcronymSentenceCase (args, kwargs, meta)
+--     kwargs['case'] = 'sentence'
+--     kwargs['case_target'] = 'long'
+--     return replaceAcronym(args, kwargs, meta)
+-- end
+
+function replaceAcronymWithDefaultValues (default_values)
+    local function shortcode (args, kwargs, meta)
+        for option_key, option_value in pairs(default_values) do
+            -- If the option was not already defined in the kwargs,
+            -- set the default value.
+            if getOrNil(kwargs[option_key]) == nil then
+                kwargs[option_key] = option_value
+            end
+        end
+        return replaceAcronym(args, kwargs, meta)
+    end
+    return shortcode
 end
+
 
 --[[
     Generate the List of Acronyms in the document.
@@ -154,9 +169,9 @@ return {
     ["acronym"] = replaceAcronym,
     -- Same function but with a shorter name.
     ["acr"] = replaceAcronym,
-    -- Capitalized shortcodes for sentence case
-    ["Acronym"] = replaceAcronymSentenceCase,
-    ["Acr"] = replaceAcronymSentenceCase,
+    -- A few shortcuts (variations of the shortcode name that enable
+    -- default options, such as case and plural).
+    ["Acronym"] = replaceAcronymWithDefaultValues({ ["case"] = "sentence" }),
+    ["Acr"] = replaceAcronymWithDefaultValues({ ["case"] = "sentence" }),
     ["print-acronyms"] = generateListOfAcronyms,
 }
- 

--- a/_extensions/acronyms/shortcodes_acronyms.lua
+++ b/_extensions/acronyms/shortcodes_acronyms.lua
@@ -106,6 +106,14 @@ function replaceAcronym (args, kwargs, meta)
     end
 end
 
+--[[
+    Wrapper for sentence case acronyms
+]]--
+function replaceAcronymSentenceCase (args, kwargs, meta)
+    kwargs['case'] = 'sentence'
+    kwargs['case_target'] = 'long'
+    return replaceAcronym(args, kwargs, meta)
+end
 
 --[[
     Generate the List of Acronyms in the document.
@@ -146,5 +154,9 @@ return {
     ["acronym"] = replaceAcronym,
     -- Same function but with a shorter name.
     ["acr"] = replaceAcronym,
+    -- Capitalized shortcodes for sentence case
+    ["Acronym"] = replaceAcronymSentenceCase,
+    ["Acr"] = replaceAcronymSentenceCase,
     ["print-acronyms"] = generateListOfAcronyms,
 }
+ 

--- a/example.qmd
+++ b/example.qmd
@@ -11,6 +11,8 @@ acronyms:
   # Each acronym must have a `shortname` and a `longname`.
   - shortname: RL
     longname: Reinforcement Learning
+  - shortname: pb
+    longname: personal budget
   # `loa_title` is used to change the name of the List of Acronyms generated.
   loa_title: "Glossary"
   # `insert_loa` determines where the List of Acronyms is placed.
@@ -28,3 +30,5 @@ This paragraph mentions \acr{RL} for the first time.
 And now, in this paragraph, \acr{RL} is in short form.
 
 Using a shortcode: {{< acr RL >}}.
+
+The long form {{< Acr pb >}} is capitalized, while the short form {{< Acr pb >}} is not.


### PR DESCRIPTION
In some languages, the long form is always capitalized. In other languages long forms are not capitalized, which makes it harder to use acronyms at the start of sentences. To prevent having to use `{{< acr KEY case=sentence >}}` throughout a document, this PR introduces capitalized versions of the `\acr` and `\acrs` command, as well as the `{{< acr ... >}}` shortcode. 

When using `\Acr`, `\Acrs`, `{{< Acronym ... >}}` or `{{< Acr ... >}}`, `case` is set to `'sentence'` and `case_target` is set to `'long'`. 

This last part might be up for discussion: by setting `case_target`, the user is prevented to set it to `'both'` or `'short'`. Maybe the code should be expanded to 'upgrade' `case_target` to `'both'` if the user sets it to `'short'`?