### PR TITLE
Add option for LoA header level

### DIFF
--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -56,6 +56,9 @@ local Options = {
     -- the `{shortname}` and `{longname}` placeholders will be replaced.
     loa_format = nil,
 
+    -- The header level to use for the List of Acronyms header.
+    loa_header_level = 1,
+
 }
 
 
@@ -139,6 +142,10 @@ function Options:parseOptionsFromMetadata(m)
         else
             self.loa_format = pandoc.utils.stringify(options["loa_format"])
         end
+    end
+
+    if options['loa_header_level'] ~= nil then
+        self.loa_header_level = math.floor(tonumber(pandoc.utils.stringify(options['loa_header_level'])) or error("Could not cast '" .. tostring(options['loa_header_level']) .. "' to number."))
     end
 end
 

--- a/_extensions/acronyms/acronyms_options.lua
+++ b/_extensions/acronyms/acronyms_options.lua
@@ -145,7 +145,18 @@ function Options:parseOptionsFromMetadata(m)
     end
 
     if options['loa_header_level'] ~= nil then
-        self.loa_header_level = math.floor(tonumber(pandoc.utils.stringify(options['loa_header_level'])) or error("Could not cast '" .. tostring(options['loa_header_level']) .. "' to number."))
+        local str_value = pandoc.utils.stringify(options["loa_header_level"])
+        local float_value = tonumber(str_value)
+        if float_value ~= nil then
+            -- Just in case the user set a float value
+            self.loa_header_level = math.floor(float_value)
+        else
+            quarto.log.error(
+                "[acronyms] Could not cast", str_value, "to an integer.",
+                "Please set option `loa_header_level` to a valid integer value."
+            )
+            assert(false)
+        end
     end
 end
 

--- a/_extensions/acronyms/acronyms_pandoc.lua
+++ b/_extensions/acronyms/acronyms_pandoc.lua
@@ -198,6 +198,7 @@ end
     - title: the header title ; use `''` (the empty string) to avoid generating
         a header (the user wants to create the header manually).
     - header_classes: the table of extra classes to put to the header.
+    - header_level: the (integer) level for the List of Acronyms heading.
 --]]
 function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_classes, header_level)
     -- Original idea from https://gist.github.com/RLesur/e81358c11031d06e40b8fef9fdfb2682
@@ -237,7 +238,14 @@ function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_class
     end
     
     header_level = header_level or Options['loa_header_level']
-    header_level = math.floor(tonumber(header_level) or error("Could not cast '" .. tostring(header_level) .. "' to number."))
+    if tonumber(header_level) == nil then
+        quarto.log.error(
+            "[acronyms] Could not cast", header_level, "to number.",
+            "Please set the `header_level` to a valid integer value."
+        )
+        assert(false)
+    end
+    header_level = math.floor(tonumber(header_level))
     quarto.log.debug("[acronyms] Using header level", tostring(header_level))
 
     -- Create the Header (only if the title is not empty)

--- a/_extensions/acronyms/acronyms_pandoc.lua
+++ b/_extensions/acronyms/acronyms_pandoc.lua
@@ -199,7 +199,7 @@ end
         a header (the user wants to create the header manually).
     - header_classes: the table of extra classes to put to the header.
 --]]
-function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_classes)
+function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_classes, header_level)
     -- Original idea from https://gist.github.com/RLesur/e81358c11031d06e40b8fef9fdfb2682
 
     -- Use default options if not specified
@@ -235,6 +235,10 @@ function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_class
         -- Custom format, render acronyms based on the requested format.
         list_acronyms = AcronymsPandoc.generateCustomFormat(sorted, loa_format)
     end
+    
+    header_level = header_level or Options['loa_header_level']
+    header_level = math.floor(tonumber(header_level) or error("Could not cast '" .. tostring(header_level) .. "' to number."))
+    quarto.log.debug("[acronyms] Using header level", tostring(header_level))
 
     -- Create the Header (only if the title is not empty)
     local header = nil
@@ -244,7 +248,7 @@ function AcronymsPandoc.generateLoA(sorting, include_unused, title, header_class
         -- (from the Options) to this table. The table will also contain `"loa"`.
         local loa_classes = table.move(extra_classes, 1, #extra_classes, 2, {"loa"})
         header = pandoc.Header(
-            1,
+            header_level,
             { table.unpack(title) },
             pandoc.Attr(Helpers.key_to_id("HEADER_LOA"), loa_classes, {})
         )

--- a/_extensions/acronyms/shortcodes_acronyms.lua
+++ b/_extensions/acronyms/shortcodes_acronyms.lua
@@ -123,12 +123,14 @@ function generateListOfAcronyms (args, kwargs, meta)
     local include_unused = getBooleanOrNil(kwargs["include_unused"])
     local title = getOrNil(kwargs["title"])
     local header_classes = getOrNil(kwargs["header_classes"])
+    local header_level = getOrNil(kwargs["header_level"])
 
     local header, definition_list = AcronymsPandoc.generateLoA(
         sorting,
         include_unused,
         title,
-        header_classes
+        header_classes,
+        header_level
     )
 
     if header ~= nil then

--- a/docs/advanced/customized_loa_header.qmd
+++ b/docs/advanced/customized_loa_header.qmd
@@ -42,6 +42,31 @@ at the end, or even at your desired location, by using the
 [options](../articles/options.qmd).
 
 
+## Changing the header level
+
+By default, **acronyms** use level-1 headers (in Markdown, this corresponds
+to a single `#`) for its List of Acronyms. There are situations in which you 
+would prefer to use other levels, typically level-2, for example in a Jupyter
+notebook. This can be changed very easily by using the `loa_header_level`
+option in the document metadata.
+
+For example:
+
+```md
+---
+acronyms:
+  keys:
+    - shortname: qmd
+      longname: Quarto documents
+  loa_header_level: 2
+---
+
+## Introduction {#intro}
+
+\acr{qmd} are great!
+```
+
+
 ## Manually customizing the title
 
 You may also want to fully customize the header of the List of Acronyms; this

--- a/tests/42-loa-header/Readme.md
+++ b/tests/42-loa-header/Readme.md
@@ -1,0 +1,4 @@
+This test ensures that we can change the List of Acronyms header level,
+using the `loa_header_level` option.
+This is a simple way to change the LoA title (without redefining the title
+manually).

--- a/tests/42-loa-header/expected.md
+++ b/tests/42-loa-header/expected.md
@@ -1,0 +1,11 @@
+## List Of Acronyms {#acronyms_HEADER_LOA .loa}
+
+[qmd]{#acronyms_qmd}
+:   Quarto documents
+
+## Introduction {#intro}
+
+The List of Acronyms header level can be changed if you do not use level-1
+headers.
+
+[Quarto documents (qmd)](#acronyms_qmd) are great!

--- a/tests/42-loa-header/input.qmd
+++ b/tests/42-loa-header/input.qmd
@@ -1,0 +1,14 @@
+---
+acronyms:
+  keys:
+    - shortname: qmd
+      longname: Quarto documents
+  loa_header_level: 2
+---
+
+## Introduction {#intro}
+
+The List of Acronyms header level can be changed if you do not use level-1
+headers.
+
+\acr{qmd} are great!


### PR DESCRIPTION
Adds a metadata option `loa_header_level` and shortcode option `header_level`. Defaults to 1 (current default).

This is an easy solve for an issue where the default LoA header level (1) does not match the header level Quarto teaches (2). Also, makes it easier to add the LoA as a subsection. 

Fixes #49.